### PR TITLE
updated requirements and supported py versions in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,15 +16,15 @@ dependencies = [
 	"pandas",
 	"xarray",
 	"hydrolib-core >=0.5.2",
-	"xugrid",
-	"meshkernel <=2.0.2",
+	"xugrid >=0.6.4",
+	"meshkernel >=2.1.0",
 	"pyproj",
-	"shapely >=0.2.0",
+	"shapely >=2.0.0",
 	"scipy",
 	"pyflwdir >=0.5.4",
 	"networkx",
 ]
-requires-python = ">=3.9,<3.11" # support 3.11 after new meshkernelpy releases
+requires-python = ">=3.9"
 readme = "README.rst"
 classifiers = [
 	# https://pypi.python.org/pypi?%3Aaction=list_classifiers
@@ -36,6 +36,7 @@ classifiers = [
 	"Programming Language :: Python :: 3",
 	"Programming Language :: Python :: 3.9",
 	"Programming Language :: Python :: 3.10",
+	"Programming Language :: Python :: 3.11",
 ]
 dynamic = ['version', 'description']
 


### PR DESCRIPTION
## Issue addressed
Fixes #88

## Explanation
The minimal meshkernel requirement was updated and python 3.11 was added to the supported py versions. Furthermore, several other minimal requirements were updated.

## Checklist
- [ ] Updated tests or added new tests (in this case add ci for py 3.8/3.10/3.11)
- [x] Branch is up to date with `main`
- [ ] Tests & pre-commit hooks pass
- [ ] Updated documentation if needed
- [ ] Updated changelog.rst if needed

