### PR TITLE
moved from conda/flit to pip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,28 +25,28 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-  
+
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-  
+
       - name: Install hydromt_delft3dfm and dependencies
         run: |
           python -m pip install --upgrade pip
           python -m pip install -e .[dev]
           hydromt --models
-  
+
       - name: Conda info
         run: |
           conda info
           conda list
           pip list
-  
+
       - name: Test with pytest
         run: |
           python -m pytest --cov=hydromt_delft3dfm --cov-report xml --cov-report term
-      
+
       - uses: codecov/codecov-action@v4
         env:
           CODECOV_TOKEN: ${{secrets.CODECOV_TOKEN}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,6 @@ on:
 jobs:
   build:
 
-    defaults:
-      run:
-        shell: bash -l {0}
-
     strategy:
       fail-fast: false
       max-parallel: 5
@@ -28,29 +24,29 @@ jobs:
       cancel-in-progress: true
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: conda-incubator/setup-miniconda@v3
-        with:
-          python-version: ${{ matrix.python-version }}
-          miniforge-variant: Mambaforge
-          channels: conda-forge
-          channel-priority: strict
-          environment-file: envs/hydromt-delft3dfm.yml
-          activate-environment: hydromt-delft3dfm
+    - uses: actions/checkout@v3
 
-      - name: Conda info
-        run: |
-          conda info
-          conda list
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
 
-      - name: Install hydromt_delft3dfm
-        run: |
-          flit install --pth-file
-          hydromt --models
+    - name: Install hydromt_delft3dfm and dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install -e .[dev]
+        hydromt --models
 
-      - name: Test with pytest
-        run: |
-          python -m pytest --cov=hydromt_delft3dfm --cov-report xml --cov-report term
-      - uses: codecov/codecov-action@v4
-        env:
-          CODECOV_TOKEN: ${{secrets.CODECOV_TOKEN}}
+    - name: Conda info
+      run: |
+        conda info
+        conda list
+        pip list
+
+    - name: Test with pytest
+      run: |
+        python -m pytest --cov=hydromt_delft3dfm --cov-report xml --cov-report term
+    
+    - uses: codecov/codecov-action@v4
+      env:
+        CODECOV_TOKEN: ${{secrets.CODECOV_TOKEN}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,10 +37,8 @@ jobs:
           python -m pip install -e .[dev]
           hydromt --models
 
-      - name: Conda info
+      - name: list env contents
         run: |
-          conda info
-          conda list
           pip list
 
       - name: Test with pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        python-version: ["3.9", "3.10", "3.11"] #, "3.12"] # TODO: add 3.12 by fixing https://github.com/Deltares/hydromt_delft3dfm/issues/136
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         os: ["windows-latest"]
 
     name: ${{ matrix.os }} - py${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,29 +24,29 @@ jobs:
       cancel-in-progress: true
 
     steps:
-    - uses: actions/checkout@v3
-
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
-
-    - name: Install hydromt_delft3dfm and dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install -e .[dev]
-        hydromt --models
-
-    - name: Conda info
-      run: |
-        conda info
-        conda list
-        pip list
-
-    - name: Test with pytest
-      run: |
-        python -m pytest --cov=hydromt_delft3dfm --cov-report xml --cov-report term
-    
-    - uses: codecov/codecov-action@v4
-      env:
-        CODECOV_TOKEN: ${{secrets.CODECOV_TOKEN}}
+      - uses: actions/checkout@v3
+  
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+  
+      - name: Install hydromt_delft3dfm and dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e .[dev]
+          hydromt --models
+  
+      - name: Conda info
+        run: |
+          conda info
+          conda list
+          pip list
+  
+      - name: Test with pytest
+        run: |
+          python -m pytest --cov=hydromt_delft3dfm --cov-report xml --cov-report term
+      
+      - uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{secrets.CODECOV_TOKEN}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install hydromt_delft3dfm and dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e .[dev]
+          python -m pip install -e .[dev,test]
           hydromt --models
 
       - name: list env contents


### PR DESCRIPTION
## Issue addressed
Fixes #136

## Explanation
The installation of the conda environment on github takes 5-10 minutes (depending on the season, the temperature, or something else). This is way faster with pip (2.5 minutes) and this also drops the flit dependency. Furthermore, this way we can also test on python 3.12 (all tests pass). In the future it might be better to move to pixi (just like everyone else) and use lockfiles and such, but I think this is a useful inbetween solution.

I would also prefer to delete `envs/hydromt-delft3dfm.yml`, but it is at the moment required by `.github/workflows/docs.yml` (which also requires flit actually).

## Checklist
- [x] Updated tests or added new tests >> not relevant, but updated ci.yml
- [x] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation if needed >> not relevant
- [x] Updated changelog.rst if needed >> not relevant
