### PR TITLE
added test for setup_mesh2d_refine

### DIFF
--- a/tests/test_dflowfm.py
+++ b/tests/test_dflowfm.py
@@ -32,6 +32,24 @@ def test_read_write_config_empty_paths(tmpdir):
     assert model2.config["output"]["outputdir"] == Path(".")
 
 
+def test_setup_mesh2d_refine(tmpdir):
+    # get dummy model
+    model = DFlowFMModel(root=join(EXAMPLEDIR, "dflowfm_piave"), mode="r")
+    mesh2d = model.get_mesh('mesh2d')
+    assert mesh2d.face_coordinates.shape == (460, 2)
+    assert mesh2d.edge_coordinates.shape == (963, 2)
+    mesh1d = model.get_mesh('mesh1d')
+    assert mesh1d.edge_coordinates.shape == (1732, 2)
+
+    # refine and assert
+    model.setup_mesh2d_refine(polygon_fn=join(EXAMPLEDIR, "data","refine.geojson"))
+    mesh2d = model.get_mesh('mesh2d')
+    assert mesh2d.face_coordinates.shape == (656, 2)
+    assert mesh2d.edge_coordinates.shape == (1306, 2)
+    mesh1d = model.get_mesh('mesh1d')
+    assert mesh1d.edge_coordinates.shape == (1732, 2)
+
+
 def test_setup_channels(tmpdir):
     # Instantiate a dummy model
     model = DFlowFMModel(


### PR DESCRIPTION
## Issue addressed
Fixes #154

## Explanation
This PR increases the test coverage of workflows/mesh.py indirectly since it calls `setup_mesh2d_refine()` which was also not covered by tests yet.

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation if needed
- [x] Updated changelog.rst if needed
