### PR TITLE
updated docs to avoid hydromt v1

### DIFF
--- a/docs/getting_started/installation.rst
+++ b/docs/getting_started/installation.rst
@@ -17,59 +17,38 @@ Compared to HydroMT, HydroMT-delft3dfm has additional dependencies, namely:
 - `meshkernel-py <https://github.com/Deltares/MeshKernelPy>`_
 - `networkx <https://networkx.org/>`_
 
-If you already have a python & conda installation but do not yet have mamba installed,
-we recommend installing it into your *base* environment using:
-
-.. code-block:: console
-
-  $ conda install mamba -n base -c conda-forge
-
-If conda is prefered, we recommend install libmamba as the solver. See explaination `here <https://www.anaconda.com/blog/a-faster-conda-for-a-growing-community>`_.
-
-.. code-block:: console
-
-  $ conda install -n base conda-libmamba-solver
-  $ conda config --set solver libmamba
-
 Installation
 ============
 
-HydroMT-Delft3DFM is available from pypi.
-We recommend installing using mamba/conda from conda-forge in a new environment.
+HydroMT-Delft3DFM is available on pypi.
 
-.. Note::
+Install HydroMT-Delft3DFM in a new environment 
+----------------------------------------------
 
-    In the commands below you can exchange `mamba` for `conda`, see
-    `here <https://deltares.github.io/hydromt/latest/getting_started/installation.html#installation-guide>`_
-    for the difference between both.
-
-Install HydroMT-Delft3DFM in a new environment (recommended!)
--------------------------------------------------------------
-
-You can install HydroMT-Delft3DFM in a new environment called `hydromt-delft3dfm`.
-HydroMT-Delft3DFM is not yet available on conda-forge so we recommend installling HydroMT (core) first
-via conda-forge and then hydromt-delft3dfm and the additionnal libraries via pip.
+You can install HydroMT-Delft3DFM in a new environment (recommended!) called `hydromt-delft3dfm`.
+HydroMT-Delft3DFM is available on pypi but not yet available on conda-forge.
+Therefore, we recommend creating a conda environment and install everything with pip.
 
 .. code-block:: console
 
-  $ conda create -n hydromt-delft3dfm -c conda-forge python
+  $ conda create -n hydromt-delft3dfm python=3.11 -c conda-forge
 
-Then, activate the environment (as stated by mamba/conda) to start making use of HydroMT-delft3dfm:
-
-.. code-block:: console
-
-  conda activate hydromt-delft3dfm
-
-Finally, install Hydromt-Delft3DFM using pypi.
+Then, activate the environment:
 
 .. code-block:: console
 
-  pip install hydromt-delft3dfm
+  $ conda activate hydromt-delft3dfm
+
+Finally, install Hydromt-Delft3DFM from pypi using pip.
+
+.. code-block:: console
+
+  $ pip install hydromt-delft3dfm
 
 .. Tip::
 
     If you already have this environment with this name either remove it with
-    `conda env remove -n hydromt-delft3dfm` **or** set a new name for the environment
+    `conda remove -n hydromt-delft3dfm --all` **or** set a new name for the environment
     by adding `-n <name>` to the line below.
 
 

--- a/docs/getting_started/installation.rst
+++ b/docs/getting_started/installation.rst
@@ -24,7 +24,7 @@ we recommend installing it into your *base* environment using:
 
   $ conda install mamba -n base -c conda-forge
 
-If conda is prefered, we recommond install libmamba as the solver. See explaination `here <https://www.anaconda.com/blog/a-faster-conda-for-a-growing-community>`_.
+If conda is prefered, we recommend install libmamba as the solver. See explaination `here <https://www.anaconda.com/blog/a-faster-conda-for-a-growing-community>`_.
 
 .. code-block:: console
 
@@ -52,7 +52,7 @@ via conda-forge and then hydromt-delft3dfm and the additionnal libraries via pip
 
 .. code-block:: console
 
-  $ conda env create -n hydromt-delft3dfm -c conda-forge hydromt
+  $ conda env create -n hydromt-delft3dfm -c conda-forge python
 
 Then, activate the environment (as stated by mamba/conda) to start making use of HydroMT-delft3dfm:
 

--- a/docs/getting_started/installation.rst
+++ b/docs/getting_started/installation.rst
@@ -52,7 +52,7 @@ via conda-forge and then hydromt-delft3dfm and the additionnal libraries via pip
 
 .. code-block:: console
 
-  $ conda env create -n hydromt-delft3dfm -c conda-forge python
+  $ conda create -n hydromt-delft3dfm -c conda-forge python
 
 Then, activate the environment (as stated by mamba/conda) to start making use of HydroMT-delft3dfm:
 

--- a/docs/getting_started/installation.rst
+++ b/docs/getting_started/installation.rst
@@ -22,7 +22,7 @@ Installation
 
 HydroMT-Delft3DFM is available on pypi.
 
-Install HydroMT-Delft3DFM in a new environment 
+Install HydroMT-Delft3DFM in a new environment
 ----------------------------------------------
 
 You can install HydroMT-Delft3DFM in a new environment (recommended!) called `hydromt-delft3dfm`.


### PR DESCRIPTION
## Issue addressed
Fixes #156

## Explanation
To avoid hydromt v1 from being installed, it should not be in the `conda create` command. Since we do need pip in the environment we do install `python`. We might want to clean up the docs since there is a lot of noisy mamba information. I think at the moment there is too much focus on mamba, while it maybe saves a few minutes for the regular user. The main focus I think should therefore be on the installation commands instead. This can be easily solved by merely advising the user to install miniforge3 like I do in the [dfm_tools docs](https://deltares.github.io/dfm_tools/installation.html). Miniforge automatically uses conda-forge and supports mamba.

I also removed `env` since I think `conda create` is more appropriate, but this might not be necessary?
- https://docs.conda.io/projects/conda/en/stable/commands/env/create.html
- https://docs.conda.io/projects/conda/en/stable/commands/create.html

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation if needed
- [x] Updated changelog.rst if needed
