### PR TITLE
added support for geopandas v1

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -19,11 +19,13 @@ Added
 Changed
 -------
 - Change default spacing in setup_channels from ``None`` to ``np.inf``. (PR #133)
+
 Fixed
 -----
 - Bugfixing of reading of frictions (global), crosssections and boundaries when update. (PR #81)
 - Fixing bug related to changes to pandas TimeDelta formatting, see also https://pandas.pydata.org/docs/whatsnew/v2.2.0.html#other-deprecations. (PR #129)
 - Fixing setup_links1d2d for 2d to 1d direction. (PR #133)
+- Support for geopandas v1 (PR #158)
 
 v0.2.0 (20 November 2023)
 =========================

--- a/hydromt_delft3dfm/dflowfm.py
+++ b/hydromt_delft3dfm/dflowfm.py
@@ -1032,6 +1032,8 @@ class DFlowFMModel(MeshModel):
             logger=self.logger,
         )
         # filter extra time for geting clipped pipes within the region (better match)
+        # remove the index name to avoid "ValueError: cannot insert branchid, already exists" in pandas>=1
+        pipes.index.name = None
         pipes = gpd.sjoin(pipes, region, predicate="within")
 
         # setup crosssections

--- a/hydromt_delft3dfm/dflowfm.py
+++ b/hydromt_delft3dfm/dflowfm.py
@@ -1032,7 +1032,7 @@ class DFlowFMModel(MeshModel):
             logger=self.logger,
         )
         # filter extra time for geting clipped pipes within the region (better match)
-        # remove the index name to avoid "ValueError: cannot insert branchid, 
+        # remove the index name to avoid "ValueError: cannot insert branchid,
         # already exists" in geopandas>=1
         pipes.index.name = None
         pipes = gpd.sjoin(pipes, region, predicate="within")

--- a/hydromt_delft3dfm/dflowfm.py
+++ b/hydromt_delft3dfm/dflowfm.py
@@ -1032,7 +1032,8 @@ class DFlowFMModel(MeshModel):
             logger=self.logger,
         )
         # filter extra time for geting clipped pipes within the region (better match)
-        # remove the index name to avoid "ValueError: cannot insert branchid, already exists" in pandas>=1
+        # remove the index name to avoid "ValueError: cannot insert branchid, 
+        # already exists" in geopandas>=1
         pipes.index.name = None
         pipes = gpd.sjoin(pipes, region, predicate="within")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 ]
 dependencies = [
 	"hydromt>=0.10.0, <1", # TODO: move to hydromt>=1: https://github.com/Deltares/hydromt_delft3dfm/issues/137
-	"geopandas>=0.10, <1", # TODO: remove upper bound: https://github.com/Deltares/hydromt_delft3dfm/issues/135
+	"geopandas>=0.10, !=1.0.0", # gpd 1.0.0 has sjoin bug: https://github.com/geopandas/geopandas/issues/352
 	"numpy",
 	"pandas>=2.0.0",
 	"xarray",

--- a/tests/test_hydromt.py
+++ b/tests/test_hydromt.py
@@ -16,7 +16,6 @@ _models = {
     "piave": {
         "example": "dflowfm_piave",
         "ini": "dflowfm_build.yml",
-        "model": DFlowFMModel,
         "data": "artifact_data==v0.0.6",
         "snap_offset": 25,
         "crs": 3857,  # global section needs to be passed to build as arguments
@@ -24,7 +23,6 @@ _models = {
     "local": {
         "example": "dflowfm_local",
         "ini": "dflowfm_build_local.yml",
-        "model": DFlowFMModel,
         "data": join(TESTDATADIR, "test_data.yaml"),
         "snap_offset": 25,
         "crs": 32647,  # global section needs to be passed to build as arguments
@@ -37,7 +35,7 @@ def test_model_class(model):
     _model = _models[model]
     # read model in examples folder
     root = join(EXAMPLEDIR, _model["example"])
-    mod = _model["model"](root=root, mode="r")
+    mod = DFlowFMModel(root=root, mode="r")
     mod.read()
     # run test_model_api() method
     non_compliant_list = mod._test_model_api()
@@ -52,7 +50,7 @@ def test_model_build(tmpdir, model):
     # compare results with model from examples folder
     root = str(tmpdir.join(model))
     logger = setuplog(__name__, join(root, "hydromt.log"), log_level=10)
-    mod1 = _model["model"](
+    mod1 = DFlowFMModel(
         root=root,
         mode="w",
         data_libs=[_model["data"]],
@@ -72,10 +70,10 @@ def test_model_build(tmpdir, model):
 
     # Compare with model from examples folder
     # (need to read it again for proper geoms check)
-    mod1 = _model["model"](root=root, mode="r", logger=logger)
+    mod1 = DFlowFMModel(root=root, mode="r", logger=logger)
     mod1.read()
     root = join(EXAMPLEDIR, _model["example"])
-    mod0 = _model["model"](root=root, mode="r")
+    mod0 = DFlowFMModel(root=root, mode="r")
     mod0.read()
     # check if equal
     equal, errors = mod0._test_equal(mod1, skip_component=["geoms"])
@@ -85,3 +83,64 @@ def test_model_build(tmpdir, model):
         if len(errors) == 0:
             equal = True
     assert equal, errors
+
+
+def test_model_build_local_code(tmp_path):
+    """
+    a python code version of the local model, to make debugging easier
+    """
+    logger = setuplog(__name__, join(tmp_path, "hydromt.log"), log_level=10)
+    _model = _models["local"]
+    model = DFlowFMModel(
+        root=tmp_path,
+        mode="w",
+        data_libs=[_model["data"]],
+        network_snap_offset=_model["snap_offset"],
+        crs=_model["crs"],
+        openwater_computation_node_distance=40,
+        logger=logger
+    )
+
+    config = join(TESTDATADIR, _model["ini"])
+    opt = parse_config(config)
+    model.setup_rivers(**opt['setup_rivers'])
+    model.setup_rivers(**opt['setup_rivers1'])
+    model.setup_pipes(**opt['setup_pipes'])
+    model.setup_manholes(**opt['setup_manholes'])
+    model.setup_1dboundary(**opt['setup_1dboundary'])
+    model.setup_1dlateral_from_points(**opt['setup_1dlateral_from_points'])
+    model.setup_1dlateral_from_polygons(**opt['setup_1dlateral_from_polygons'])
+    model.setup_mesh2d(**opt['setup_mesh2d'])
+    # model.setup_mesh2d_refine(**opt['setup_mesh2d_refine'])
+    model.setup_maps_from_rasterdataset(**opt['setup_maps_from_rasterdataset'])
+    model.setup_2dboundary(**opt['setup_2dboundary'])
+    model.setup_rainfall_from_uniform_timeseries(**opt['setup_rainfall_from_uniform_timeseries'])
+    model.setup_link1d2d(**opt['setup_link1d2d'])
+
+
+def test_model_build_piave_code(tmp_path):
+    """
+    a python code version of the piave model, to make debugging easier
+    """
+    logger = setuplog(__name__, join(tmp_path, "hydromt.log"), log_level=10)
+    _model = _models["piave"]
+    model = DFlowFMModel(
+        root=tmp_path,
+        mode="w",
+        data_libs=[_model["data"]],
+        network_snap_offset=_model["snap_offset"],
+        crs=_model["crs"],
+        openwater_computation_node_distance=40,
+        logger=logger
+    )
+
+    config = join(TESTDATADIR, _model["ini"])
+    opt = parse_config(config)
+    model.setup_rivers_from_dem(**opt['setup_rivers_from_dem'])
+    model.setup_pipes(**opt['setup_pipes'])
+    model.setup_manholes(**opt['setup_manholes'])
+    model.setup_1dboundary(**opt['setup_1dboundary'])
+    model.setup_mesh2d(**opt['setup_mesh2d'])
+    model.setup_maps_from_rasterdataset(**opt['setup_maps_from_rasterdataset'])
+    model.setup_maps_from_raster_reclass(**opt['setup_maps_from_raster_reclass'])
+    model.setup_link1d2d(**opt['setup_link1d2d'])

--- a/tests/test_hydromt.py
+++ b/tests/test_hydromt.py
@@ -87,7 +87,9 @@ def test_model_build(tmpdir, model):
 
 def test_model_build_local_code(tmp_path):
     """
-    a python code version of the local model, to make debugging easier
+    A python code version of the local model, to make debugging easier.
+    This test can be removed once the entire hydromt_delft3dfm is properly
+    covered by unittests.
     """
     logger = setuplog(__name__, join(tmp_path, "hydromt.log"), log_level=10)
     _model = _models["local"]
@@ -120,7 +122,9 @@ def test_model_build_local_code(tmp_path):
 
 def test_model_build_piave_code(tmp_path):
     """
-    a python code version of the piave model, to make debugging easier
+    A python code version of the piave model, to make debugging easier.
+    This test can be removed once the entire hydromt_delft3dfm is properly
+    covered by unittests.
     """
     logger = setuplog(__name__, join(tmp_path, "hydromt.log"), log_level=10)
     _model = _models["piave"]


### PR DESCRIPTION
## Issue addressed
Fixes #135

## Explanation
Added python code versions of the build-model testcases and then debugging the geopandas v1 errors was easy. I have excluded v1.0.0 because of https://github.com/geopandas/geopandas/issues/352, but this is resolved in 1.0.1. There was only one edit needed, since `gpd.sjoin()` is not possible anymore if the index name is the same as a column name. I expect this is a bug in geopandas, which we might want to report if it is a problem for us. I can also imagine this does not matter at all, so in that case we can leave it.

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation if needed >> not needed
- [x] Updated changelog.rst if needed
