### PR TITLE
Align dflowfm buildyml

### DIFF
--- a/tests/data/dflowfm_build.yml
+++ b/tests/data/dflowfm_build.yml
@@ -1,8 +1,15 @@
+#global:
+#  crs: 3857
+#  network_snap_offset: 25
+#  openwater_computation_node_distance: 40
+# commented, because not supported with the current test method
+
 setup_rivers_from_dem:
   region: 
     bbox: [12.4331, 46.4661, 12.5212, 46.5369]
   hydrography_fn: merit_hydro
   river_geom_fn: hydro_rivers_lin
+  rivers_defaults_fn: rivers_defaults
   rivdph_method: gvf
   rivwth_method: geom
   river_upa: 25.0
@@ -14,6 +21,7 @@ setup_pipes:
   region: 
     bbox: [12.4331, 46.4661, 12.5212, 46.5369]
   pipes_fn: grip_roads
+  pipes_defaults_fn: pipes_defaults
   pipe_filter: pipe
   spacing: 50
   friction_type: WhiteColeBrook
@@ -26,7 +34,10 @@ setup_pipes:
   pipes_invlev: 3. 
 
 setup_manholes:
+  manholes_fn:
+  manhole_defaults_fn: manholes_defaults
   dem_fn: merit_hydro
+  bedlevel_shift: 0.5
 
 setup_1dboundary:
   boundary_value: -2.0
@@ -45,14 +56,16 @@ setup_maps_from_rasterdataset:
   variables: ["elevtn"]
   fill_method: nearest
   interpolation_method: nearestNb
-  split_dataset: True
 
 setup_maps_from_raster_reclass:
   raster_fn: vito_2015
   reclass_table_fn: vito_mapping
   reclass_variables: ['roughness_manning', 'infiltcap']
   interpolation_method: triangulation
-  split_dataset: True
+
+#setup_rainfall_from_constant:
+#  constant_value: 150
+# this should probably be uncommented: https://github.com/Deltares/hydromt_delft3dfm/issues/177
 
 setup_link1d2d:
   link_direction: 1d_to_2d

--- a/tests/data/dflowfm_build.yml
+++ b/tests/data/dflowfm_build.yml
@@ -3,6 +3,7 @@
 #  network_snap_offset: 25
 #  openwater_computation_node_distance: 40
 # commented, because not supported with the current test method
+# https://github.com/Deltares/hydromt_delft3dfm/issues/181
 
 setup_rivers_from_dem:
   region: 

--- a/tests/data/dflowfm_build_local.yml
+++ b/tests/data/dflowfm_build_local.yml
@@ -3,6 +3,7 @@
 #  network_snap_offset: 25
 #  openwater_computation_node_distance: 40
 # commented, because not supported with the current test method
+# https://github.com/Deltares/hydromt_delft3dfm/issues/181
 
 setup_rivers:
   region:

--- a/tests/data/dflowfm_build_local.yml
+++ b/tests/data/dflowfm_build_local.yml
@@ -1,3 +1,9 @@
+#global:
+#  crs: 32647
+#  network_snap_offset: 25
+#  openwater_computation_node_distance: 40
+# commented, because not supported with the current test method
+
 setup_rivers:
   region:
     geom: "local_data/1D_extent.geojson"

--- a/tests/test_hydromt.py
+++ b/tests/test_hydromt.py
@@ -109,6 +109,8 @@ def test_model_build_local_code(tmp_path):
     model.setup_rivers(**opt['setup_rivers1'])
     model.setup_pipes(**opt['setup_pipes'])
     model.setup_manholes(**opt['setup_manholes'])
+    model.setup_bridges(**opt['setup_bridges'])
+    model.setup_culverts(**opt['setup_culverts'])
     model.setup_1dboundary(**opt['setup_1dboundary'])
     model.setup_1dlateral_from_points(**opt['setup_1dlateral_from_points'])
     model.setup_1dlateral_from_polygons(**opt['setup_1dlateral_from_polygons'])


### PR DESCRIPTION
## Issue addressed
Fixes #171
Fixes #176 (duplicate)

## Explanation
While working on #74 @xldeltares noticed the dflowfm_build.yml files in testdata and examples were not the same anymore. I updated the one in testdata, but kept some parts commented since adding that would fail the `test_model_build` tests. I have created follow up issues for those here: https://github.com/Deltares/hydromt_delft3dfm/issues/177 and https://github.com/Deltares/hydromt_delft3dfm/issues/181. Furthermore, while working on the same PR, I notices two missing buildsteps in `test_model_build_local_code`, which I also added here.

## Additionally
- I accidentally created this PR, while this one also partly covers the same issue already: https://github.com/Deltares/hydromt_delft3dfm/pull/172 (I closed that one to avoid confusion)
- the build-docs action fails, will be resolved in https://github.com/Deltares/hydromt_delft3dfm/pull/180

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation if needed >> not needed
- [x] Updated changelog.rst if needed >> not needed
