### PR TITLE
delete sediment section from mdu

### DIFF
--- a/hydromt_delft3dfm/dflowfm.py
+++ b/hydromt_delft3dfm/dflowfm.py
@@ -2951,6 +2951,9 @@ class DFlowFMModel(MeshModel):
         mdu = FMModel(**cf_dict)
         # add filepath
         mdu.filepath = mdu_fn
+        # temporarily remove sediment section to avoid error in Delft3D FM 1D2D 2024.03
+        # https://issuetracker.deltares.nl/browse/FM1D2D-3047
+        del mdu.sediment
         # write
         mdu.save(recurse=False)
         # Go back to working dir


### PR DESCRIPTION
## Issue addressed
Fixes #183

## Explanation
Temporarily remove the unused sediment section to avoid errors in the DeltaShell. This to work around a bug in DeltaShell, now also reported in https://issuetracker.deltares.nl/browse/FM1D2D-3047.

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation if needed
- [x] Updated changelog.rst if needed
