### PR TITLE
Drop support for py39

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,9 @@ jobs:
 
     strategy:
       fail-fast: false
-      max-parallel: 5
+      max-parallel: 4
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
         os: ["windows-latest"]
 
     name: ${{ matrix.os }} - py${{ matrix.python-version }}

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,6 +15,7 @@ Added
 
 Changed
 -------
+- Dropped support for Python 3.9. (PR #XXX)
 
 Fixed
 -----

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,7 +15,7 @@ Added
 
 Changed
 -------
-- Dropped support for Python 3.9. (PR #XXX)
+- Dropped support for Python 3.9. (PR #214)
 
 Fixed
 -----

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "pyflwdir>=0.5.4",
     "networkx",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 readme = "README.rst"
 classifiers = [
     # https://pypi.python.org/pypi?%3Aaction=list_classifiers
@@ -36,7 +36,6 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Hydrology",
     "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -81,7 +80,7 @@ dflowfm = "hydromt_delft3dfm.dflowfm:DFlowFMModel"
 
 [tool.black]
 line-length = 88
-target-version = ['py39']
+target-version = ['py310']
 
 [tool.ruff]
 line-length = 88


### PR DESCRIPTION
## Issue addressed
Fixes #213 

## Explanation
Removed support for Python 3.9 in pyproject.toml and updated the github workflows

## Checklist
- [X] Updated tests or added new tests
- [X] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [ ] Updated documentation if needed <-- did not find the version specified anywhere
- [X] Updated changelog.rst if needed

## Additional Notes (optional)

