### PR TITLE
Feat/bcascii generic meteo forcing

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,7 +8,7 @@ The format is based on `Keep a Changelog`_, and this project adheres to
 
 UNRELEASED
 ==========
-This release supports Python 3.11 and up.
+This release supports Python 3.11 and up. Some new features are only available from D-Flow FM version 2027.01 onwards.
 
 Added
 -----
@@ -18,6 +18,7 @@ Added
 - Updated to hydrolib-core v1 (pydantic V2 API) (PR #226)
 - New method **setup_spatial_forcing** (PR #263)
 - New method **setup_constant_meteo** and **setup_timeseries_meteo** (PR #276)
+- Extended bcascii support to all meteo quantities (PR #324)
 
 Changed
 -------

--- a/hydromt_delft3dfm/dflowfm.py
+++ b/hydromt_delft3dfm/dflowfm.py
@@ -2732,18 +2732,10 @@ class DFlowFMModel(Model):
         Prepare space-uniform meteo forcing from a constant value.
 
         The forcing is written as a bcAscii meteorological forcing block.
-        See the D-Flow FM User Manual 1D2D, Section C.5.
+        See the D-Flow FM User Manual 1D2D/2D3D, Section C.5.
 
-        Quantity names in a bc block for meteorological forcings, Section C.5.3:
-
-        - rainfall
-        - rainfall_rate
-        - windxy
-        - windx
-        - windy
-
-        Use ``constant_value`` to quickly set up a spatially uniform and temporally
-        constant forcing for testing.
+        Supported quantity names in a bc forcing block for meteorological forcings are
+        documented in Section C.5.3/C.6.3.
 
         Call the function multiple times to set up different types of meteorological
         forcing, e.g. rainfall and wind.
@@ -2798,15 +2790,10 @@ class DFlowFMModel(Model):
         Prepare space-uniform meteo forcing from a timeseries file.
 
         The forcing is written as a bcAscii meteorological forcing block.
-        See the D-Flow FM User Manual 1D2D, Section C.5.
+        See the D-Flow FM User Manual 1D2D/2D3D, Section C.5.
 
-        Quantity names in a bc block for meteorological forcings, Section C.5.3:
-
-        - rainfall
-        - rainfall_rate
-        - windxy
-        - windx
-        - windy
+        Supported quantity names in a bc forcing block for meteorological forcings are
+        documented in Section C.5.3/C.6.3.
 
         Use ``meteo_timeseries_fn`` when providing a
         user-defined timeseries.

--- a/hydromt_delft3dfm/utils/translate_utils.py
+++ b/hydromt_delft3dfm/utils/translate_utils.py
@@ -51,11 +51,26 @@ DICT_VARNAME_TO_DFLOWFM = {
 }
 
 METEO_UNITS = {
-    "rainfall_rate": "mm/day",
-    "rainfall": "mm",
     "windxy": "m/s",
     "windx": "m/s",
     "windy": "m/s",
+    "airpressure": "N/m2",
+    "atmosphericpressure": "N/m2",
+    "charnock": "-",
+    "pseudoAirPressure": "N/m2",
+    "waterLevelCorrection": "m",
+    "rainfall_rate": "mm/day",
+    "rainfall": "mm",
+    "humidity": "-",
+    "cloudiness": "-",
+    "airdensity": "kg/m3",
+    "airtemperature": "◦C",
+    "dewpoint": "◦C",
+    "longwaveradiation": "W/m2",
+    "sensibleheatflux": "W/m2",
+    "latentheatflux": "W/m2",
+    "netsolarradiation": "W/m2",
+    "solarradiation": "W/m2",
 }
 
 
@@ -93,18 +108,11 @@ def meteo_unit_from_type(meteo_type: str):
     """Get the meteo units from the meteo type string.
 
     Type of meteorological forcing to prepare. Supported values are
-    ``"rainfall_rate"``, ``"rainfall"``, ``"windxy"``, ``"windx"``, and
-    ``"windy"`` (as of delft3dfm 2026.02). Might be resolved in
-    https://github.com/Deltares/hydromt_delft3dfm/issues/311.
+    documented in the D-Flow FM User Manual, Section C.5.3 and C.6.3.
+    All meteo quantities are supported as of delft3dfm 2027.01 (DIMRset 2.31.19).
 
     Units follow from the METEO_UNITS translation dictionary in the module
-    :py:meth:`~hydromt_delft3dfm.utils.translate_utils`.
-
-    Corresponding units are:
-
-    - ``"rainfall_rate"``: ``"mm/day"``
-    - ``"rainfall"``: ``"mm"``
-    - ``"windxy"``, ``"windx"``, ``"windy"``: ``"m/s"``
+    :py:meth:`~hydromt_delft3dfm.utils.translate_utils`.`
     """
     if meteo_type not in METEO_UNITS:
         raise ValueError(

--- a/hydromt_delft3dfm/utils/translate_utils.py
+++ b/hydromt_delft3dfm/utils/translate_utils.py
@@ -27,7 +27,6 @@ DICT_VARNAME_TO_DFLOWFM = {
     "v10n": "windy",  # CDS varname: 10m_v_component_of_neutral_wind
     "msl": "airpressure",  # CDS varname: mean_sea_level_pressure
     "chnk": "charnock",  # CDS varname: charnock
-    "sst": "sea_surface_temperature",  # CDS varname: sea_surface_temperature
     "t2m": "airtemperature",  # CDS varname: 2m_temperature
     # TODO: when adding dewpointtemperature/netsolarradiation/others,
     #  also update `mdu.physics.temperature = 5`

--- a/hydromt_delft3dfm/utils/translate_utils.py
+++ b/hydromt_delft3dfm/utils/translate_utils.py
@@ -107,7 +107,7 @@ def meteo_unit_from_type(meteo_type: str):
     """Get the meteo units from the meteo type string.
 
     Type of meteorological forcing to prepare. Supported values are
-    documented in the D-Flow FM User Manual, Section C.5.3 and C.6.3.
+    documented in the D-Flow FM User Manual 1D2D/2D3D, Section C.5.3 and C.6.3.
     All meteo quantities are supported as of delft3dfm 2027.01 (DIMRset 2.31.19).
 
     Units follow from the METEO_UNITS translation dictionary in the module

--- a/tests/test_translate_utils.py
+++ b/tests/test_translate_utils.py
@@ -1,5 +1,8 @@
 import pytest
-from hydromt_delft3dfm.utils.translate_utils import varname_to_dflowfm_quantity
+from hydromt_delft3dfm.utils.translate_utils import (
+    meteo_unit_from_type,
+    varname_to_dflowfm_quantity,
+)
 from hydromt_delft3dfm.utils.translate_utils import (
     DICT_VARNAME_TO_DFLOWFM,
     METEO_UNITS,
@@ -28,6 +31,13 @@ def test_varname_to_dflowfm_quantity_notpresent():
     with pytest.raises(KeyError) as e:
         _ = varname_to_dflowfm_quantity(varname)
     assert "varname u10_typo not in keys or values of translation" in str(e.value)
+
+
+def test_meteo_unit_from_type():
+    with pytest.raises(KeyError) as e:
+        _ = meteo_unit_from_type("aaa")
+    assert "Unsupported meteo_type 'aaa'. Supported values are" in str(e.value)
+
 
 def test_consistency_varnames_units():
     exceptions = ["sea_surface_temperature"]

--- a/tests/test_translate_utils.py
+++ b/tests/test_translate_utils.py
@@ -1,5 +1,9 @@
 import pytest
 from hydromt_delft3dfm.utils.translate_utils import varname_to_dflowfm_quantity
+from hydromt_delft3dfm.utils.translate_utils import (
+    DICT_VARNAME_TO_DFLOWFM,
+    METEO_UNITS,
+)
 
 def test_varname_to_dflowfm_quantity_hydromt():
     varname = "precip"
@@ -24,3 +28,12 @@ def test_varname_to_dflowfm_quantity_notpresent():
     with pytest.raises(KeyError) as e:
         _ = varname_to_dflowfm_quantity(varname)
     assert "varname u10_typo not in keys or values of translation" in str(e.value)
+
+def test_consistency_varnames_units():
+    exceptions = ["sea_surface_temperature"]
+    for quantity in DICT_VARNAME_TO_DFLOWFM.values():
+        if quantity in METEO_UNITS.keys():
+            continue
+        if quantity in exceptions:
+            continue
+        raise KeyError(f"quantity '{quantity}' not in METEO_UNITS keys.")

--- a/tests/test_translate_utils.py
+++ b/tests/test_translate_utils.py
@@ -34,7 +34,12 @@ def test_varname_to_dflowfm_quantity_notpresent():
 
 
 def test_meteo_unit_from_type():
-    with pytest.raises(KeyError) as e:
+    unit = meteo_unit_from_type("airpressure")
+    assert unit == "N/m2"
+
+
+def test_meteo_unit_from_type_unsupported_quantity():
+    with pytest.raises(ValueError) as e:
         _ = meteo_unit_from_type("aaa")
     assert "Unsupported meteo_type 'aaa'. Supported values are" in str(e.value)
 

--- a/tests/test_translate_utils.py
+++ b/tests/test_translate_utils.py
@@ -45,10 +45,7 @@ def test_meteo_unit_from_type_unsupported_quantity():
 
 
 def test_consistency_varnames_units():
-    exceptions = ["sea_surface_temperature"]
     for quantity in DICT_VARNAME_TO_DFLOWFM.values():
         if quantity in METEO_UNITS.keys():
-            continue
-        if quantity in exceptions:
             continue
         raise KeyError(f"quantity '{quantity}' not in METEO_UNITS keys.")


### PR DESCRIPTION
## Issue addressed
Fixes #311

## Explanation
DIMRset 2.31.19 will have support for other meteo quantities than windx/windy/windxy/rainfall/rainfall_rate in the bc file. Therefore, allow these other quantities in hydromt_delft3dfm also.

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation if needed
- [x] Updated changelog.rst if needed: `extended support to all meteo quantities in bcascii files, supported by FM version 2027.01 (DIMRset 2.31.19)`

## To discuss
- might be better to get the units from the data, instead of hard-coding them. If we hard-code them, it would be nice to check if they are the same as the data (if present).
- check if all units are correct