### PR TITLE
convert release/publish workflow to pixi

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,9 +5,6 @@ on:
   release:
     types:
       - published
-  push:
-    tags:
-      - 'v*'
 
 
 jobs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,9 +14,9 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up Pixi
-        uses: prefix-dev/setup-pixi@v0.9.4
+        uses: prefix-dev/setup-pixi@v0.10.0
         with:
-          pixi-version: "v0.70.2"
+          pixi-version: "v0.77.0"
           environments: default
 
       - name: List env contents

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,6 @@ on:
     types:
       - published
 
-
 jobs:
   build-artifacts:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,107 +14,29 @@ jobs:
   build-artifacts:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v4
-        name: Install Python
+      - name: Set up Pixi
+        uses: prefix-dev/setup-pixi@v0.9.4
         with:
-          python-version: 3.9
+          pixi-version: "v0.70.2"
+          environments: default
 
-      - name: Install dependencies
+      - name: List env contents
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install flit wheel twine
+          pixi list
 
       - name: Build tarball and wheels
         run: |
-          git clean -xdf
-          git restore -SW .
-          flit build
+          pixi run flit build
 
       - name: Check built artifacts
         run: |
-          python -m twine check dist/*
-          pwd
+          pixi run twine check dist/*
 
-      - uses: actions/upload-artifact@v3
-        with:
-          name: releases
-          path: dist
-
-  test-built-dist:
-    needs: build-artifacts
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash -l {0}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v3
-        with:
-          name: releases
-          path: dist
-      - name: List contents of built dist
+      - name: Build and publish
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
         run: |
-          ls -ltrh
-          ls -ltrh dist
-
-      - name: Setup environment
-        uses: conda-incubator/setup-miniconda@v3
-        with:
-          python-version: "3.11"
-          channels: conda-forge
-          channel-priority: strict
-
-      - name: Install hydromt-delft3dfm dependencies
-        run: |
-          conda install flit
-          flit install --only-deps
-
-      - name: Conda info
-        run: |
-          conda info
-          conda list
-          pip list
-
-      - name: Verify the built dist/wheel is valid
-        run: |
-          python -m pip install dist/hydromt_delft3dfm*.whl
-          python -c 'from hydromt_delft3dfm import __version__ as v; print(v)'
-          echo "hydromt --models"
-
-  upload-to-test-pypi:
-    needs: test-built-dist
-    if: github.event_name == 'push'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/download-artifact@v3
-        with:
-          name: releases
-          path: dist
-      - name: Publish package to TestPyPI
-        uses: pypa/gh-action-pypi-publish@v1.5.1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_TEST_TOKEN }}
-          repository_url: https://test.pypi.org/legacy/
-          verbose: true
-          skip_existing: true
-
-  upload-to-pypi:
-    needs: test-built-dist
-    if: github.event_name == 'release'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/download-artifact@v3
-        with:
-          name: releases
-          path: dist
-      - name: Publish package to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.5.1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_TOKEN }}
-          verbose: true
+          pixi run twine upload dist/*


### PR DESCRIPTION
## Issue addressed
Fixes #325

## Explanation
Significantly simplified the publising workflow since most of the steps are not really adding value in my view:
- `hydromt --models` is not asserting an expected value. It would make sense to install the wheel if we would also run the tests, but we do not do this. This would also require having a clean pixi environment to be of added value to the regular tests.
- i've never used test-pypi. If you make a mistake the upload just fails and you can repair the workflow and try again, so why bother?
- using basic commands/tools from the environment instead of using external actions, for simplification. Added benefit: this way it can also be used/tested locally.

## Checklist
- [ ] Updated tests or added new tests >> not applicable
- [x] Branch is up to date with `main`
- [x] Tests & pre-commit hooks pass
- [ ] Updated documentation if needed >> not applicable
- [ ] Updated changelog.rst if needed >> not applicable

## Additional Notes (optional)
Maybe we should consider adding a clean pixi environment for this, but it might not matter that much.
